### PR TITLE
make the name of the CA file configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 This is how I deploy Kubernetes to DigitalOcean.
 This aims to be generic enough to also deploy your infrastructure but there
 might be some specifics. The biggest limitation right now is that all servers
-are both master and minion which is discouraged for any lager infrastructure.
+are both master and minion which is discouraged for any larger infrastructure.
 
 While it's possible that this will become a generic way to setup any kind of
 Kubernetes infrastructures, it's not a top priority. If interested in a
@@ -31,6 +31,9 @@ First you might want to edit `config/env` to customize:
 - `SERVERS`: Number of servers
 - `SERVER_SIZE`: Size of servers
 - `IP_INT_PREFIX`: Prefix to use for internal private network (tinc)
+- `CA_FILE`: The full path (on the servers) for your TLS CA cert file
+
+You might also want to edit `config/ca/ca-csr.json`.
 
 Then run `mk_credentials` to create TLS CA and keys in `config/generated/`.
 

--- a/config/env
+++ b/config/env
@@ -3,3 +3,4 @@ DOMAIN=int.5pi.de
 SERVERS=3
 SERVER_SIZE=512mb
 IP_INT_PREFIX=10.130
+CA_FILE=/etc/ssl/5pi-ca.pem

--- a/packer/Makefile
+++ b/packer/Makefile
@@ -15,4 +15,4 @@ all: check_dirty
 		base.json
 
 check_dirty:
-	git status --porcelain | grep -q '^ M ' && false || true
+	git diff-index --quiet HEAD

--- a/packer/files/etc/bash_completion.d/aliases.sh
+++ b/packer/files/etc/bash_completion.d/aliases.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
-torus_etcd_flags="-C https://$(hostname):2379 --etcd-ca-file /etc/ssl/5pi-ca.pem --etcd-cert-file /etc/ssl/server.pem --etcd-key-file /etc/ssl/server-key.pem"
+torus_etcd_flags="-C https://$(hostname):2379 --etcd-ca-file ${CA_FILE} --etcd-cert-file /etc/ssl/server.pem --etcd-key-file /etc/ssl/server-key.pem"
 
 alias torusctl="torusctl $torus_etcd_flags"
 alias torusblk="torusblk $torus_etcd_flags"
 
-alias etcdctl="etcdctl --endpoints https://$(hostname):2379 --ca-file /etc/ssl/5pi-ca.pem --cert-file /etc/ssl/server.pem --key-file /etc/ssl/server-key.pem"
-alias curla="curl -E /etc/ssl/server.pem --key /etc/ssl/server-key.pem --cacert /etc/ssl/5pi-ca.pem"
+alias etcdctl="etcdctl --endpoints https://$(hostname):2379 --ca-file ${CA_FILE} --cert-file /etc/ssl/server.pem --key-file /etc/ssl/server-key.pem"
+alias curla="curl -E /etc/ssl/server.pem --key /etc/ssl/server-key.pem --cacert ${CA_FILE}"

--- a/packer/files/lib/systemd/system/etcd.service
+++ b/packer/files/lib/systemd/system/etcd.service
@@ -15,13 +15,13 @@ ExecStart=/usr/bin/etcd --name master${INDEX} \
   --client-cert-auth \
   --cert-file /etc/ssl/server.pem \
   --key-file /etc/ssl/server-key.pem \
-  --trusted-ca-file /etc/ssl/5pi-ca.pem \
+  --trusted-ca-file ${CA_FILE} \
   \
   --listen-peer-urls "https://${IP_INT}:2380" \
   --peer-client-cert-auth \
   --peer-cert-file /etc/ssl/server.pem \
   --peer-key-file /etc/ssl/server-key.pem \
-  --peer-trusted-ca-file /etc/ssl/5pi-ca.pem \
+  --peer-trusted-ca-file ${CA_FILE} \
   \
   --heartbeat-interval 200 \
   --election-timeout 5000 \

--- a/packer/files/lib/systemd/system/k8s-apiserver.service
+++ b/packer/files/lib/systemd/system/k8s-apiserver.service
@@ -14,8 +14,8 @@ ExecStart=/usr/bin/hyperkube apiserver \
   --apiserver-count $SERVERS \
   --tls-cert-file /etc/ssl/server.pem \
   --tls-private-key-file /etc/ssl/server-key.pem \
-  --client-ca-file /etc/ssl/5pi-ca.pem \
-  --etcd-cafile /etc/ssl/5pi-ca.pem \
+  --client-ca-file ${CA_FILE} \
+  --etcd-cafile ${CA_FILE} \
   --etcd-certfile /etc/ssl/server.pem \
   --etcd-keyfile /etc/ssl/server-key.pem \
   --cert-dir /etc/kubernetes \

--- a/packer/files/lib/systemd/system/k8s-controller-manager.service
+++ b/packer/files/lib/systemd/system/k8s-controller-manager.service
@@ -9,7 +9,7 @@ User=k8s
 ExecStart=/usr/bin/hyperkube controller-manager \
   --address ${IP_INT} \
   --service-account-private-key-file /etc/kubernetes/serviceaccount.key \
-  --root-ca-file /etc/ssl/5pi-ca.pem \
+  --root-ca-file ${CA_FILE} \
   --leader-elect \
   --master http://localhost:8080
 Restart=on-failure

--- a/packer/files/lib/systemd/system/torusd.service
+++ b/packer/files/lib/systemd/system/torusd.service
@@ -12,7 +12,7 @@ ExecStart=/usr/bin/torusd \
   --data-dir /var/lib/torus \
   --size $TORUS_SIZE \
   --etcd https://%H:2379 \
-  --etcd-ca-file /etc/ssl/5pi-ca.pem \
+  --etcd-ca-file ${CA_FILE} \
   --etcd-cert-file /etc/ssl/server.pem \
   --etcd-key-file /etc/ssl/server-key.pem
 Restart=always

--- a/packer/files/usr/libexec/etcd-remove-self
+++ b/packer/files/usr/libexec/etcd-remove-self
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 ETCDCTL="etcdctl --endpoints https://$(hostname):2379 \
-  --ca-file /etc/ssl/5pi-ca.pem --cert-file /etc/ssl/server.pem --key-file /etc/ssl/server-key.pem"
+  --ca-file ${CA_FILE} --cert-file /etc/ssl/server.pem --key-file /etc/ssl/server-key.pem"
 
 ID=$($ETCDCTL member list | awk -F: "/name=$(hostname) / { print \$1 }")
 

--- a/packer/files/usr/libexec/kubernetes/kubelet-plugins/volume/exec/coreos.com~torus/torus
+++ b/packer/files/usr/libexec/kubernetes/kubelet-plugins/volume/exec/coreos.com~torus/torus
@@ -2,7 +2,7 @@
 
 exec /usr/bin/torusblk \
   -C https://`hostname`:2379 \
-	--etcd-ca-file /etc/ssl/5pi-ca.pem \
+	--etcd-ca-file ${CA_FILE} \
 	--etcd-cert-file /etc/ssl/server.pem \
 	--etcd-key-file /etc/ssl/server-key.pem \
   "$@"

--- a/packer/install.sh
+++ b/packer/install.sh
@@ -62,7 +62,7 @@ $(cat $n/rsa_key.pub)
 EOF
   let i++ || true
 done
-cp /tmp/config/generated/ca.pem /etc/ssl/5pi-ca.pem
+cp /tmp/config/generated/ca.pem ${CA_FILE}
 
 # Set docker options
 sed -i 's/^ExecStart=.*/& --storage-driver=overlay --iptables=false --ip-masq=false --bip ${IP_INT_PREFIX}.${INDEX}.1/' /lib/systemd/system/docker.service 

--- a/tf/configure.sh
+++ b/tf/configure.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 exec > /tmp/configure.log 2>&1
 ETCDCTL_BASE="etcdctl \
-  --ca-file /etc/ssl/5pi-ca.pem \
+  --ca-file ${CA_FILE} \
   --cert-file /etc/ssl/server.pem \
   --key-file /etc/ssl/server-key.pem"
 ETCDCTL="$ETCDCTL_BASE --endpoints https://$(hostname):2379"


### PR DESCRIPTION
Most of this code introduces an environment variable for the name of the CA file.

I also fixed:
* one typo in the README (spelling of "larger"), and
* a bug in the `packer/Makefile` (`grep ... && false || true` is always `true` -- at least on OS X -- and so cannot detect dirty repo)
